### PR TITLE
docs: fix typo 'unlockedd'

### DIFF
--- a/docs/devrel/devrel.md
+++ b/docs/devrel/devrel.md
@@ -4,4 +4,4 @@ sidebar_position: 0
 
 # DevRel Unlocked
 
-DevRel unlockedd
+DevRel unlocked


### PR DESCRIPTION
fixed `unlockedd` to `unlocked`
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Documentation: Fixed a typographical error in the developer relations guide. The text "DevRel unlockedd" has been corrected to "DevRel unlocked". This change improves the readability and understanding of the document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->