### PR TITLE
(fix):Changed Linkfree to Biodrop 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -191,7 +191,7 @@ const config = {
             title: 'More',
             items: [
               {
-                label: 'Biodrop',
+                label: 'BioDrop',
                 to: 'https://www.biodrop.io/FrancescoXX',
               },
               {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -191,8 +191,8 @@ const config = {
             title: 'More',
             items: [
               {
-                label: 'Linkfree',
-                to: 'https://linkfree.io/FrancescoXX',
+                label: 'Biodrop',
+                to: 'https://www.biodrop.io/FrancescoXX',
               },
               {
                 label: 'GitHub',


### PR DESCRIPTION
Issue: #56

 - Renamed Linkfree to "BioDrop" in the footer section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Refactor: 

- Updated the navigation menu item from "Linkfree" to "BioDrop". 
- The associated URL has been changed from "https://linkfree.io/FrancescoXX" to "https://www.biodrop.io/FrancescoXX". 

These changes reflect the rebranding of the product and will direct users to the new BioDrop website when they click on the updated menu item."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->