### PR TITLE
docs: add funding links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: francescoxx
+custom: https://paypal.me/FCiulla


### PR DESCRIPTION
fixes #53 

add github and paypal sponsor button

*please do not consider this for hacktoberfest*
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated the `.github/FUNDING.yml` file to include a GitHub username (`francescoxx`) and a custom PayPal link (`https://paypal.me/FCiulla`). No changes were made to the functionality or behavior of the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->